### PR TITLE
Fixup RubyDoc links and add logger dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Test Coverage](https://codeclimate.com/github/sugarcrm/rspec-side_effects/badges/coverage.svg)](https://codeclimate.com/github/sugarcrm/rspec-side_effects/coverage)
 [![License](http://img.shields.io/badge/license-Apache2-green.svg?style=flat)](LICENSE)
 
-[![RubyDoc](http://img.shields.io/badge/docs-rdoc.info-blue.svg)](http://rubydoc.org/gems/rspec-side_effects)
+[![RubyDoc](http://img.shields.io/badge/docs-rdoc.info-blue.svg)](http://rubydoc.info/gems/rspec-side_effects)
 
 RSpec extension for checking the side effects of your specifications.
 

--- a/rspec-side_effects.gemspec
+++ b/rspec-side_effects.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   # without limiting.
   spec.add_development_dependency 'bundler-audit'
   spec.add_development_dependency 'license_finder'
+  spec.add_development_dependency 'logger'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rake'


### PR DESCRIPTION
The `logger` develpment dependency will be needed by `license_finder` in Ruby v3.5 because the logger will no longer be included by default.